### PR TITLE
Clean up language in the code

### DIFF
--- a/blase/fn.go
+++ b/blase/fn.go
@@ -16,7 +16,7 @@ type fnargs struct {
 	tA    C.cblas_transpose
 	tB    C.cblas_transpose
 
-	// shit that needs to be passed to C in a very unsafe manner
+	// things that needs to be passed to C in a very unsafe manner
 	a0 uintptr
 	a1 uintptr
 	a2 uintptr

--- a/cmd/cudagen/main.go
+++ b/cmd/cudagen/main.go
@@ -156,7 +156,6 @@ func main() {
 
 	f.Write([]byte("}\n"))
 
-	// gofmt and goimports this shit
 	cmd := exec.Command("gofmt", "-w", gorgoniaLoc+"/cudamodules.go")
 	if err = cmd.Run(); err != nil {
 		log.Fatalf("Go imports failed with %v for %q", err, gorgoniaLoc+"/cudamodules.go")

--- a/node.go
+++ b/node.go
@@ -323,7 +323,7 @@ func (n *Node) Grad() (Value, error) {
 		return n.deriv.Value(), nil
 	}
 
-	return nil, errors.Errorf("No Gradient node/value found for %v", n)
+	return nil, errors.Errorf("No Gradient node/value found for %T", n)
 }
 
 // Dims indicates how many dimensions the node's result has

--- a/tensor/dense_svd_test.go
+++ b/tensor/dense_svd_test.go
@@ -186,7 +186,7 @@ func TestDense_SVD(t *testing.T) {
 		}
 	}
 
-	// illogical stuff
+	// this is illogical
 	T = New(Of(Float64), WithShape(2, 2))
 	if _, _, _, err = T.SVD(false, true); err == nil {
 		t.Errorf("Expected an error!")

--- a/tensor/tensor.go
+++ b/tensor/tensor.go
@@ -41,11 +41,11 @@ type Tensor interface {
 	Eq
 	Cloner
 
-	// type overloading stuff
+	// type overloading methods
 	IsScalar() bool
 	ScalarValue() interface{}
 
-	// view related stuff
+	// view related methods
 	IsView() bool
 	Materialize() Tensor
 

--- a/typeSystem_test.go
+++ b/typeSystem_test.go
@@ -164,7 +164,7 @@ func init() {
 		{"Tensor Float64", newTensorType(1, Float64), false, false},
 		{"Tensor Float64 (special)", newTensorType(0, Float64), true, false},
 
-		// bad shit
+		// this is bad
 		{"a", hm.TypeVariable('a'), false, true},
 		{"malformed", malformed{}, false, true},
 	}
@@ -178,7 +178,7 @@ func init() {
 		{Float64, Float64, false},
 		{newTensorType(1, Float64), Float64, false},
 
-		// bad shit
+		// this is bad
 		// {hm.TypeVariable('a'), MAXDTYPE, true},
 		// {hm.TypeVariable('a'), MAXDTYPE, true},
 		// {newTensorType(1, hm.TypeVariable('a')), MAXDTYPE, true},

--- a/vm_genera_test.go
+++ b/vm_genera_test.go
@@ -98,7 +98,7 @@ func TestLispMachineMechanics(t *testing.T) {
 	assert.True(ValueEq(grad, xG))
 	assert.True(ValueEq(grad, yG))
 
-	// tack more shit onto the graph, and execute it again
+	// tack more items onto the graph, and execute it again
 	szp2 := Must(Add(sz, twof64))
 	szp3 := Must(Add(sz, threef64))
 


### PR DESCRIPTION
In anticipation of 1.0, some of the lively language in the comments were
toned down a wee bit.