### PR TITLE
Fixed up the issues that gotip has found

### DIFF
--- a/op_tensor_test.go
+++ b/op_tensor_test.go
@@ -268,20 +268,20 @@ func TestTransposeOp(t *testing.T) {
 
 	var ag, bg Value
 	if ag, err = A.Grad(); err != nil {
-		t.Fatalf("Cannot get grad of A", err)
+		t.Fatalf("Cannot get grad of A. Err: %v", err)
 	}
 
 	if bg, err = B.Grad(); err != nil {
-		t.Fatalf("Cannot get grad of B", err)
+		t.Fatalf("Cannot get grad of B. Err: %v", err)
 	}
 
 	var costGrad1, costGrad2 Value
 	if costGrad1, err = cost1.Grad(); err != nil {
-		t.Fatalf("Cannot get grad of Cost1")
+		t.Fatalf("Cannot get grad of Cost1. Err %v", err)
 	}
 
 	if costGrad2, err = cost2.Grad(); err != nil {
-		t.Fatalf("Cannot get grad of Cost2")
+		t.Fatalf("Cannot get grad of Cost2. Err %v", err)
 	}
 
 	t.Logf("%v %v", cost1.Value(), cost2.Value())

--- a/operatorPointwise_unary_test.go
+++ b/operatorPointwise_unary_test.go
@@ -57,13 +57,13 @@ func unaryOpTest(t *testing.T, dt tensor.Dtype, shape tensor.Shape, fn func(*Nod
 
 	Let(x, xV)
 	if err = m0.RunAll(); err != nil {
-		t.Errorf("m0 failed:", err)
+		t.Errorf("m0 failed: %v", err)
 		return
 	}
 
 	Let(a, aV)
 	if err = m1.RunAll(); err != nil {
-		t.Errorf("m1 failed:", err)
+		t.Errorf("m1 failed: %v", err)
 		return
 	}
 

--- a/vm_tape.go
+++ b/vm_tape.go
@@ -143,8 +143,7 @@ func (m *tapeMachine) Set(a, b *Node) (err error) {
 	breg := m.locMap[b]
 	v := m.getValue(breg)
 	if v == nil {
-		err = errors.Errorf(nyiFail, "handling of Memory -> Value")
-		return
+		return nyi("handling of Memory -> Value", "tapeMachine.Set")
 	}
 
 	machineLogf("Setting %v to %v. Read from %v Value is %v", b, a, breg, v)
@@ -173,8 +172,7 @@ func (m *tapeMachine) Run(frag fragment) (err error) {
 
 		v := m.getValue(r)
 		if v == nil {
-			err = errors.Errorf(nyiFail, "converting Memory to Value")
-			return
+			return nyi("converting Memory to Value", "TapeMachine.Run")
 		}
 
 		if err = n.bind(m.cpumem[r.id]); err != nil {
@@ -213,7 +211,6 @@ func (m *tapeMachine) RunAll() (err error) {
 				return err
 			}
 			return nil
-		default:
 		}
 	}
 	return
@@ -654,7 +651,7 @@ func (instr *readInstr) exec(m *tapeMachine) (err error) {
 	m.logf("Executing READ - read from %v into %v", instr.readFrom, instr.into)
 	v := m.getValue(instr.readFrom)
 	if v == nil {
-		return errors.Errorf(nyiFail, "Cannot read instruction")
+		return nyi("value of nil", "readInstr.exec")
 	}
 
 	v2, err := CloneValue(v)


### PR DESCRIPTION
Go is a lot more religious in checking for string interpolation and formatting now.